### PR TITLE
Broken old API Call by projectName+projectVersion

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,12 +31,17 @@ try {
     encodedBomContents = encodedBomContents.substring(4);
   }
 
-  const bomPayload = {
-    project: project,
-    projectName: projectName,
-    projectVersion: projectVersion,
-    autoCreate: autoCreate,
-    bom: encodedBomContents
+  if (project == "") {
+    const bomPayload = {
+      projectName: projectName,
+      projectVersion: projectVersion,
+      autoCreate: autoCreate,
+      bom: encodedBomContents
+    }
+  } else {
+    const bomPayload = {
+      project: project,
+      bom: encodedBomContents
   }
 
   const postData = JSON.stringify(bomPayload);


### PR DESCRIPTION
If you call the DependencyTrack Endpoint without project (UUID) and only projectName and projectVersion then you'll get an not specified error through GitHub Actions. That is because "project" is still supplied in the body. The field "project" needs to be excluded if the call does not contain the UUID. Alternative project can be set to null.

Not working Request:

```
{
    "project": "",
    "projectName": "mcbs/test99",
    "projectVersion": "local",
    "autoCreate" : "true",
    "bom":  "base64"
}
```

Error Message:
```
[
    {
        "message": "The project must be a valid 36 character UUID",
        "messageTemplate": "The project must be a valid 36 character UUID",
        "path": "project",
        "invalidValue": ""
    }
]
```

Working Requests:

```
{
    "project": null,
    "projectName": "mcbs/test99",
    "projectVersion": "local",
    "autoCreate" : "true",
    "bom":  "base64"
}
```

```
{
    "projectName": "mcbs/test99",
    "projectVersion": "local",
    "autoCreate" : "true",
    "bom":  "base64"
}
```