### PR TITLE
Bump Node from 12 to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,5 +34,5 @@ inputs:
     default: 'bom.xml'
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'


### PR DESCRIPTION
resolves #9

I'm not sure what to do with updating `@actions/core` to a current version (1.10.0) it seems there is only a [`package-lock.json`](https://github.com/DependencyTrack/gh-upload-sbom/blob/master/package-lock.json) file and no `package.json`... and the `node_modules` directory has been committed to VC