### PR TITLE
Updated index.js to fix autoCreate without Project UUID

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This action uploads a software bill of materials file to a Dependency-Track serv
 
 ## Inputs
 
-### `serverhostname`
+### `serverHostname`
 
 **Required** Dependency-Track hostname
 
@@ -18,7 +18,7 @@ Can be `https` or `http`
 
 Defaults to `https`
 
-### `apikey`
+### `apiKey`
 
 **Required** Dependency-Track API key
 
@@ -26,19 +26,19 @@ Defaults to `https`
 
 **Required, unless projectname and projectversion are provided** Project uuid in Dependency-Track
 
-### `projectname`
+### `projectName`
 
 **Required, unless project is provided** Project name in Dependency-Track
 
-### `projectversion`
+### `projectVersion`
 
 **Required, unless project is provided** Project version in Dependency-Track
 
-### `autocreate`
+### `autoCreate`
 
 Automatically create project and version in Dependency-Track, default `false`
 
-### `bomfilename`
+### `bomFilename`
 
 Path and filename of the BOM, default `bom.xml`
 
@@ -48,17 +48,34 @@ With project name and version:
 ```
 uses: DependencyTrack/gh-upload-sbom@v2.0.0
 with:
-  serverhostname: 'example.com'
-  apikey: ${{ secrets.DEPENDENCYTRACK_APIKEY }}
-  projectname: 'Example Project'
-  projectversion: 'master'
+  serverHostname: 'example.com'
+  apiKey: ${{ secrets.DEPENDENCYTRACK_APIKEY }}
+  projectName: 'Example Project'
+  projectVersion: 'master'
+  bomFilename: "/path/to/bom.xml"
+  autoCreate: true
+```
+
+With protocol, port and project name:
+```
+  - name: SBOM zu DependencyTrack senden
+    uses: DependencyTrack/gh-upload-sbom@v2.0.0
+    with:
+      protocol: ${{ secrets.DEPENDENCYTRACK_PROTOCOL }}
+      serverHostname: ${{ secrets.DEPENDENCYTRACK_HOSTNAME }}
+      port: ${{ secrets.DEPENDENCYTRACK_PORT }}
+      apiKey: ${{ secrets.DEPENDENCYTRACK_APIKEY }}
+      projectName: 'Example Project'
+      projectVersion: 'master'
+      bomFilename: "/path/to/bom.xml"
+      autoCreate: true
 ```
 
 With project uuid:
 ```
 uses: DependencyTrack/gh-upload-sbom@v2.0.0
 with:
-  serverhostname: 'example.com'
-  apikey: ${{ secrets.DEPENDENCYTRACK_APIKEY }}
+  serverHostname: 'example.com'
+  apiKey: ${{ secrets.DEPENDENCYTRACK_APIKEY }}
   project: 'dadec8ad-7053-4e8c-8044-7b6ef698e08d'
 ```

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   port:
     description: 'Dependency-Track port'
     required: false
-    default: 443
+    default: '443'
   protocol:
     description: 'Dependency-Track protocol'
     required: false

--- a/index.js
+++ b/index.js
@@ -15,12 +15,12 @@ try {
   const bomFilename = core.getInput('bomfilename');
 
 
-  if (protocol != "http" && protocol != "https") {
+  if (protocol !== "http" && protocol !== "https") {
     throw 'protocol "' + protocol + '" not supported, must be one of: https, http'
   }
-  const client = (protocol == "http") ? http : https
+  const client = (protocol === "http") ? http : https
 
-  if (project == "" && (projectName == "" || projectVersion == "")) {
+  if (project === "" && (projectName === "" || projectVersion === "")) {
     throw 'project or projectName + projectVersion must be set'
   }
 


### PR DESCRIPTION
Looks like #12  got closed without the fix being merged, so I'll do it again.

Issue #16 and #17 should be resolved with this.

Changes:
* Updates the API body and added checks for valid combinations
* Readme.md got 2 extra paragraphs showcasing the new calls