### PR TITLE
feat: include tags when creating

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Defaults to `https`
 
 **Required, unless project is provided** Project version in Dependency-Track
 
+### `projectTags`
+
+Project tags in Dependency-Track
+
 ### `autoCreate`
 
 Automatically create project and version in Dependency-Track, default `false`
@@ -64,6 +68,19 @@ with:
   apiKey: ${{ secrets.DEPENDENCYTRACK_APIKEY }}
   projectName: 'Example Project'
   projectVersion: 'master'
+  bomFilename: "/path/to/bom.xml"
+  autoCreate: true
+```
+
+With project name, version and tags:
+```
+uses: DependencyTrack/gh-upload-sbom@v2.0.0
+with:
+  serverHostname: 'example.com'
+  apiKey: ${{ secrets.DEPENDENCYTRACK_APIKEY }}
+  projectName: 'Example Project'
+  projectVersion: 'master'
+  projectTags: 'tag1,tag2'
   bomFilename: "/path/to/bom.xml"
   autoCreate: true
 ```

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,10 @@ inputs:
   projectversion:
     description: 'Project version in Dependency-Track'
     required: false
+  projecttags:
+    description: 'Project tags in Dependency-Track'
+    default: ''
+    required: false
   autocreate:
     description: "Automatically create the project in Dependency-Track if it doesn't exist"
     default: 'false'

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ try {
   const project = core.getInput('project');
   const projectName = core.getInput('projectname');
   const projectVersion = core.getInput('projectversion');
+  const projectTags = core.getInput('projecttags').split(',').map(tag => tag.trim());
   const autoCreate = core.getInput('autocreate') !== 'false';
   const bomFilename = core.getInput('bomfilename');
   const parent = core.getInput('parent');
@@ -50,6 +51,7 @@ try {
     bomPayload = {
       projectName: projectName,
       projectVersion: projectVersion,
+      projectTags: projectTags.map(tag => ({name: tag})),
       autoCreate: autoCreate,
       bom: encodedBomContents
     }


### PR DESCRIPTION
Added projectTags property to be able to specify tags when autoCreate is True. #29 

This is possible thanks to the new dependency track functionality DependencyTrack/dependency-track#3843