### PR TITLE
chore: update action runtime to Node.js 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,5 +47,5 @@ inputs:
     description: 'Parent project version in Dependency-Track (available in DT v4.8 and later)'
     required: false
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'index.js'


### PR DESCRIPTION
GitHub is deprecating the Node.js 20 runtime for actions and emits warnings for actions still using node20. Bump the action runtime to node24. The action code relies only on the global fetch (stable since Node 18), fs, Buffer, URL and `@actions/core`, so no code changes are required.

Closes https://github.com/DependencyTrack/gh-upload-sbom/issues/53